### PR TITLE
Allow BACKUP_NAME to be set by the user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You need to add a user with the following policies. Be sure to change `your_buck
 }
 ```
 
-## Extra environmnet
+## Extra environment
 
 - `S3_PATH` - Default value is `mongodb`. Example `s3://your_bucket/mongodb`
 - `MONGO_COMPLETE` - Default not set. If set doing backup full mongodb

--- a/README.md
+++ b/README.md
@@ -104,7 +104,12 @@ You need to add a user with the following policies. Be sure to change `your_buck
 - `MONGO_COMPLETE` - Default not set. If set doing backup full mongodb
 - `MAX_BACKUPS` - Default not set. If set doing it keeps the last n backups in /backup
 - `BACKUP_NAME` - Default is `$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz`. If set this is the name of the backup file. Useful when using s3 versioning. (Remember to place .gz extension on your filename)
-- `EXTRA_OPTIONS` - Default not set. You would probably need `--authenticationDatabase=admin`
+- `EXTRA_OPTIONS` - Default not set.
+
+## Troubleshoot
+
+1. If you get SASL Authentication failure, add  `--authenticationDatabase=admin` to EXTRA_OPTIONS.
+2. If you get "Failed: error writing data for collection ... Unrecognized field 'snapshot'", add `--forceTableScan` to EXTRA_OPTIONS.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker run -d --name mongodump \
   lgatica/mongodump-s3
 ```
 
-### Inmediatic backup
+### Immediate backup
 
 ```bash
 docker run -d --name mongodump \
@@ -65,9 +65,9 @@ docker run -d --name mongodump \
   lgatica/mongodump-s3
 ```
 
-## IAM Policiy
+## IAM Policy
 
-You need to add a user with the following policies. Be sure to change `your_bucket` by the correct.
+You need to add a user with the following policies. Be sure to change `your_bucket` by the correct name.
 
 ```xml
 {

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You need to add a user with the following policies. Be sure to change `your_buck
 - `MONGO_COMPLETE` - Default not set. If set doing backup full mongodb
 - `MAX_BACKUPS` - Default not set. If set doing it keeps the last n backups in /backup
 - `BACKUP_NAME` - Default is `$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz`. If set this is the name of the backup file. Useful when using s3 versioning. (Remember to place .gz extension on your filename)
+- `EXTRA_OPTIONS` - Default not set. You would probably need `--authenticationDatabase=admin`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ docker run -d --name mongodump \
   lgatica/mongodump-s3
 ```
 
-## IAM Policity
+## IAM Policiy
 
 You need to add a user with the following policies. Be sure to change `your_bucket` by the correct.
 
@@ -103,6 +103,7 @@ You need to add a user with the following policies. Be sure to change `your_buck
 - `S3_PATH` - Default value is `mongodb`. Example `s3://your_bucket/mongodb`
 - `MONGO_COMPLETE` - Default not set. If set doing backup full mongodb
 - `MAX_BACKUPS` - Default not set. If set doing it keeps the last n backups in /backup
+- `BACKUP_NAME` - Default is `$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz`. If set this is the name of the backup file. Useful when using s3 versioning. (Remember to place .gz extension on your filename)
 
 ## License
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
-OPTIONS=`python /usr/local/bin/mongouri`
+OPTIONS=`python mongouri.py`
+OPTIONS="$OPTIONS $EXTRA_OPTIONS"
 DEFAULT_BACKUP_NAME="$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz"
 BACKUP_NAME=${BACKUP_NAME:-$DEFAULT_BACKUP_NAME}
 

--- a/backup.sh
+++ b/backup.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 
 OPTIONS=`python /usr/local/bin/mongouri`
-BACKUP_NAME="$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz"
+DEFAULT_BACKUP_NAME="$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz"
+BACKUP_NAME=${BACKUP_NAME:-$DEFAULT_BACKUP_NAME}
 
 # Run backup
 mongodump ${OPTIONS} -o /backup/dump

--- a/backup.sh
+++ b/backup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-OPTIONS=`python mongouri.py`
+OPTIONS=`python /usr/local/bin/mongouri`
 OPTIONS="$OPTIONS $EXTRA_OPTIONS"
 DEFAULT_BACKUP_NAME="$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz"
 BACKUP_NAME=${BACKUP_NAME:-$DEFAULT_BACKUP_NAME}


### PR DESCRIPTION
This allows BACKUP_NAME to be set by the user via the environment variable `BACKUP_NAME`. This is useful if the s3 bucket has versioning enabled and the user wants to manage the backups using s3 versioning.

Also fixes a few spellings.