### PR TITLE
Fix mongodump with old mongoldb version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.7@sha256:8c03bb07a531c53ad7d0f6e7041b64d81f99c6e493cb39abba56d956b40eacbc
+FROM alpine:3.22
 
 MAINTAINER Leonardo Gatica <lgatica@protonmail.com>
 
-RUN apk add --no-cache mongodb-tools py2-pip && \
-  pip install pymongo awscli && \
+RUN apk add --update --no-cache mongodb-tools py-pip && \
+  pip install --break-system-packages pymongo awscli && \
   mkdir /backup
 
 ENV S3_PATH=mongodb AWS_DEFAULT_REGION=us-east-1
@@ -14,4 +14,4 @@ COPY mongouri.py /usr/local/bin/mongouri
 
 VOLUME /backup
 
-CMD /usr/local/bin/entrypoint
+CMD [ "/usr/local/bin/entrypoint" ]

--- a/backup.sh
+++ b/backup.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env sh
 
 OPTIONS=`python /usr/local/bin/mongouri`
-BACKUP_NAME="$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.gz"
+BACKUP_NAME="$(date -u +%Y-%m-%d_%H-%M-%S)_UTC.tar"
 
 # Run backup
-mongodump ${OPTIONS} -o /backup/dump
+mongodump --forceTableScan --gzip ${OPTIONS} -o /backup/dump
 # Compress backup
-cd /backup/ && tar -cvzf "${BACKUP_NAME}" dump
+cd /backup/ && tar -cvf "${BACKUP_NAME}" dump
 # Upload backup
 aws s3 cp "/backup/${BACKUP_NAME}" "s3://${S3_BUCKET}/${S3_PATH}/${BACKUP_NAME}"
 # Delete temp files


### PR DESCRIPTION
Add --forceTableScan to be compatible with old versions
Add --gzip to produce compressed dumps to use less storage during backup
Changed archive to simple tar as dumps are already compressed
Upgrade alpine to latest